### PR TITLE
feat: Shortcode attributes

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -94,6 +94,7 @@ class Helper
             'description',
             'type',
             'status',
+            'shortcode_attributes',
             'tags',
             'created_at',
             'updated_at',

--- a/app/Hooks/Handlers/AdminMenuHandler.php
+++ b/app/Hooks/Handlers/AdminMenuHandler.php
@@ -34,8 +34,9 @@ class AdminMenuHandler
         $currentUser = wp_get_current_user();
 
         [$tags, $groups] = (new Snippet())->getAllSnippetTagsGroups();
-
-        add_action('wp_print_scripts', function () {
+	    $shortcodeAttributes = ( new Snippet() )->getAllShortcodeAttributes();
+		
+	    add_action( 'wp_print_scripts', function () {
 
             $isSkip = apply_filters('fluent_snippets/skip_no_conflict', false);
 
@@ -111,6 +112,7 @@ class AdminMenuHandler
             ],
             'i18n'                       => Trans::getStrings(),
             'tags'                       => $tags,
+            'shortcode_attributes' => $shortcodeAttributes,
             'groups'                     => $groups,
             'safeModes'                  => $this->getSafeModeInfo(),
             'is_standalone'              => defined('FLUENT_SNIPPETS_RUNNING_MU'),

--- a/app/Hooks/Handlers/CodeHandler.php
+++ b/app/Hooks/Handlers/CodeHandler.php
@@ -52,16 +52,11 @@ class CodeHandler
         (new CodeRunner())->runSnippets();
     }
 
-    public function handleShortcode($atts, $content = null)
-    {
-        $atts = shortcode_atts([
-            'id' => '',
-        ], $atts);
-
-        $fileName = $atts['id'];
-        if (empty($fileName)) {
-            return '';
-        }
+	public function handleShortcode( $atts, $content = null ) {
+		$fileName = $atts['id'];
+		if ( empty( $fileName ) ) {
+			return '';
+		}
 
         $config = Helper::getIndexedConfig();
 
@@ -97,8 +92,21 @@ class CodeHandler
         if (!$conditionalClass->evaluate(Arr::get($snippet, 'condition', []))) {
             return $this->shortCodeError(__('Snippet condition is not valid', 'easy-code-manager'));
         }
-        
-        ob_start();
+
+		$shortcodeAttributes   = Arr::get( $snippet, 'meta.shortcode_attributes', [] );
+		$shortcodeAttributes   = explode( ',', $shortcodeAttributes );
+		$shortcodeAttributes[] = 'id';
+
+		if ( is_array( $shortcodeAttributes ) ) {
+			$allowedAtts = array_intersect_key( $atts, array_flip( $shortcodeAttributes ) );
+			if ( $allowedAtts !== $atts ) {
+				return $this->shortCodeError( __( 'Shortcode attributes are not valid', 'easy-code-manager' ) );
+			}
+
+			extract( $allowedAtts, EXTR_SKIP );
+		}
+
+		ob_start();
 
         $maybeReturn = include $snippet['file'];
 

--- a/app/Model/Snippet.php
+++ b/app/Model/Snippet.php
@@ -243,7 +243,37 @@ class Snippet
         return [array_values($allTags), array_values($allGroups)];
     }
 
-    public function findByFileName($fileName)
+	public function getAllShortcodeAttributes() {
+		$config = Helper::getIndexedConfig();
+
+		if ( ! $config || empty( $config['meta'] ) ) {
+			return [];
+		}
+
+		if ( empty( $config['published'] ) && empty( $config['draft'] ) ) {
+			return [];
+		}
+
+		$snippets = array_merge( $config['published'], $config['draft'] );
+		if ( ! $snippets ) {
+			return [];
+		}
+
+		$allAttributes = [];
+
+		foreach ( $snippets as $snippet ) {
+			if ( ! empty( $snippet['shortcode_attributes'] ) ) {
+				$attributes    = array_map( 'trim', explode( ',', $snippet['shortcode_attributes'] ) );
+				$allAttributes = array_merge( $allAttributes, $attributes );
+			}
+		}
+
+		$allAttributes = array_unique( $allAttributes );
+
+		return array_values( $allAttributes );
+	}
+
+	public function findByFileName($fileName)
     {
         $snippetDir = Helper::getStorageDir();
         $file = $snippetDir . '/' . $fileName;
@@ -375,7 +405,8 @@ class Snippet
             'run_at'       => '',
             'group'        => '',
             'condition'    => '',
-            'load_as_file' => ''
+            'load_as_file'         => '',
+            'shortcode_attributes' => ''
         ];
 
         foreach ($docBlock as $key => $value) {
@@ -439,7 +470,8 @@ class Snippet
                 'status' => 'no',
                 'run_if' => 'assertive',
                 'items'  => [[]]
-            ]
+            ],
+            'shortcode_attributes' => ''
         ];
 
         $metaData = Arr::only($metaData, array_keys($metaDefaults));

--- a/app/Services/CodeRunner.php
+++ b/app/Services/CodeRunner.php
@@ -252,6 +252,7 @@ class CodeRunner
         $docBlockArray = [
             'name'        => '',
             'status'      => '',
+            'shortcode_attributes' => '',
             'tags'        => '',
             'description' => '',
             'type'        => '',

--- a/src/components/_ShortcodeAttributeCreator.vue
+++ b/src/components/_ShortcodeAttributeCreator.vue
@@ -1,0 +1,61 @@
+<template>
+    <div class="select_plus_wrap">
+        <el-select v-model="dynamicAttributes" :fit-input-width="true" :multiple="true"
+                   :placeholder="$t('Select Shortcode Attributes')" allow-create clearable
+                   filterable @change="updated()">
+            <el-option v-for="attribute in appVars.shortcode_attributes" :label="attribute"
+                       :value="attribute"></el-option>
+        </el-select>
+        <el-popover :visible="createPop" :width="400" placement="left" trigger="click">
+            <template #reference>
+                <el-button @click="createPop = true">+</el-button>
+            </template>
+            <el-input
+                v-model="inputValue"
+                :placeholder="$t('Create a new attribute')"
+            >
+            </el-input>
+            <el-button style="margin-top: 10px;" type="primary" @click="handleInputConfirm()">{{ $t('Add') }}
+            </el-button>
+        </el-popover>
+    </div>
+</template>
+
+<script type="text/babel">
+export default {
+    name: 'ShortcodeAttributeCreator',
+    props: ['modelValue'],
+    $emits: ['update:modelValue'],
+    data() {
+        return {
+            dynamicAttributes: [],
+            inputVisible: false,
+            inputValue: '',
+            createPop: false
+        }
+    },
+    methods: {
+        handleInputConfirm() {
+            let inputValue = this.inputValue;
+            if (inputValue) {
+                // check if the tag already in this.dynamicAttributes
+                if (this.dynamicAttributes.indexOf(inputValue) === -1) {
+                    this.dynamicAttributes.push(inputValue);
+                }
+            }
+            this.appVars.shortcode_attributes.push(inputValue);
+            this.createPop = false;
+            this.inputValue = '';
+            this.updated();
+        },
+        updated() {
+            this.$emit('update:modelValue', this.dynamicAttributes.join(','));
+        }
+    },
+    mounted() {
+        if (this.modelValue) {
+            this.dynamicAttributes = this.modelValue.split(',').map(tag => tag.trim());
+        }
+    }
+}
+</script>

--- a/src/components/_SnippetForm.vue
+++ b/src/components/_SnippetForm.vue
@@ -100,6 +100,21 @@
 
                 </el-form-item>
 
+                <el-form-item v-if="snippet.meta.run_at === 'shortcode'" class="snippet_tags_item">
+                    <template #label>
+                        <span>
+                            {{ $t('Shortcode Attributes') }} <el-tooltip
+                            class="box-item"
+                            content="Define attributes that you want to expose to the snippet."
+                            effect="dark"
+                            placement="top-start"
+                        >
+                            <el-button :icon="InfoField" size="small" style="font-style: italic" text></el-button>
+                          </el-tooltip>
+                        </span>
+                    </template>
+                    <shortcode-attribute-creator v-model="snippet.meta.shortcode_attributes"/>
+                </el-form-item>
             </el-col>
         </el-row>
     </el-form>
@@ -107,6 +122,7 @@
 
 <script type="text/babel">
 import TagCreator from './_TagCreator.vue'
+import ShortcodeAttributeCreator from './_ShortcodeAttributeCreator.vue'
 import CodeEditor from './_CodeEditor.vue'
 import {InfoFilled} from '@element-plus/icons-vue';
 import {markRaw} from "vue";
@@ -117,6 +133,7 @@ import WhereRun from './_WhereRun';
 export default {
     name: 'SnippetForm',
     components: {
+        ShortcodeAttributeCreator,
         TagCreator,
         CodeEditor,
         SelectPlus,


### PR DESCRIPTION
Wanted to finally contribute something to oss, so I added the option to use attributes/variables to shortcodes.
For each snippet is a tag-like selector which forces you to select what variables to use in the script and shortcode (otherwise any shortcode user could overwrite any variables in the whole function).

Let me know if there's anything else to change.

References: #27 

P.S.: I think the last Commit didn't run as `npx mix --production` but commited the same `watch`. That's why there's a ton of removals. Probably all the whitespace in app.js


## Github Copilot Summary
This pull request introduces functionality for handling shortcode attributes in snippets. The changes span multiple files, adding new methods and updating existing ones to support this feature.

### Shortcode Attributes Handling:

* [`app/Helpers/Helper.php`](diffhunk://#diff-90413b9eaaf1fd6fd3efa830a9f5ea9413b46ad7bf14744ec697b5b4507e1143R97): Added `shortcode_attributes` to the list of fields.

* [`app/Hooks/Handlers/AdminMenuHandler.php`](diffhunk://#diff-233f4d780c2c1eec36a720dfb7049c9175fa596b54d95f7780c0f35753ed1d67R37): Updated the `render` method to retrieve and pass `shortcode_attributes` to the view. [[1]](diffhunk://#diff-233f4d780c2c1eec36a720dfb7049c9175fa596b54d95f7780c0f35753ed1d67R37) [[2]](diffhunk://#diff-233f4d780c2c1eec36a720dfb7049c9175fa596b54d95f7780c0f35753ed1d67R115)

* [`app/Hooks/Handlers/CodeHandler.php`](diffhunk://#diff-f22b98bbad4dd701795b09cdac9beefb485ada06f367218280ad2e71544395fdL55-R55): Enhanced the `handleShortcode` method to validate and process shortcode attributes. [[1]](diffhunk://#diff-f22b98bbad4dd701795b09cdac9beefb485ada06f367218280ad2e71544395fdL55-R55) [[2]](diffhunk://#diff-f22b98bbad4dd701795b09cdac9beefb485ada06f367218280ad2e71544395fdR96-R108)

* [`app/Model/Snippet.php`](diffhunk://#diff-c29ec99e09f980500fc9375d03b9472cd5e149a0cfaca7f49597c5ff1da36d5cR246-R275): Added `getAllShortcodeAttributes` method and updated `parseBlock` and `parseInputMeta` methods to handle `shortcode_attributes`. [[1]](diffhunk://#diff-c29ec99e09f980500fc9375d03b9472cd5e149a0cfaca7f49597c5ff1da36d5cR246-R275) [[2]](diffhunk://#diff-c29ec99e09f980500fc9375d03b9472cd5e149a0cfaca7f49597c5ff1da36d5cL378-R409) [[3]](diffhunk://#diff-c29ec99e09f980500fc9375d03b9472cd5e149a0cfaca7f49597c5ff1da36d5cL442-R474)

### Frontend Components:

* [`src/components/_ShortcodeAttributeCreator.vue`](diffhunk://#diff-fb269460cfc70e0081c2ae23868a43a2fa6ab022753b5246dcc105a4bb99ae9aR1-R61): Introduced a new component to create and manage shortcode attributes.

* [`src/components/_SnippetForm.vue`](diffhunk://#diff-95032081ad9f0a706f4f58dd7af1370296fbd332c8f600c86a8cf7972a781d57R103-R125): Integrated `ShortcodeAttributeCreator` into the snippet form to allow users to define shortcode attributes. [[1]](diffhunk://#diff-95032081ad9f0a706f4f58dd7af1370296fbd332c8f600c86a8cf7972a781d57R103-R125) [[2]](diffhunk://#diff-95032081ad9f0a706f4f58dd7af1370296fbd332c8f600c86a8cf7972a781d57R136)