### PR TITLE
Enhance handleShortcode to retain user arguments

### DIFF
--- a/app/Hooks/Handlers/CodeHandler.php
+++ b/app/Hooks/Handlers/CodeHandler.php
@@ -51,10 +51,18 @@ class CodeHandler
 
     public function handleShortcode($atts, $content = null)
     {
+        $original = (array)$atts;
+        
         $atts = shortcode_atts([
             'id' => '',
-        ], $atts);
+        ], $original);
 
+        // Unlike the core function, keep any user arguments in the array. 
+        // This allows [fluent_snippet id="3-snippet" type="test"] such that a snippet can look up the argument in $atts['type'].
+        // Note: The below is to cover if the 3rd parameter to shortcode_atts was added i.e. to allow filtering
+        unset( $original['id'] );
+        $atts = array_merge( $atts, $original );
+        
         $fileName = $atts['id'];
         if (empty($fileName)) {
             return '';


### PR DESCRIPTION
We'd like the ability to pass arguments to a snippet.

This for example allows the user to specify  [fluent_snippet id="3-snippet" type="test"] as a shortcode.

The original code uses shortcode_atts, that removes any unknown short codes - so the type=test is pulled out.

The below patch, still calls shortcode_atts, but then removes id, and merges the arrays. I've left the call to shortcode_atts rather then calling a different function in case wordpress change the functionality later on. The only addition to shortcode_atts is a 3rd parameter which would allow filtering. 

An addition to the patch included here, would be to do:

if( isset( $atts[id'] ) $atts = shortcode_atts([
            'id' => '',
        ], $atts, $atts['id']);
        
 This would mean that apply_filter would be called - which may be an useful addition, but I can't immediately think of a use case for this (especially given I believe there is some conditional options within the plugin itself)


