### PR TITLE
Add custom snippets storage path feature

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -7,9 +7,88 @@ use FluentSnippets\App\Services\PhpValidator;
 
 class Helper
 {
+    /**
+     * Get the storage directory path for snippets.
+     *
+     * Users can customize this path by:
+     * 1. Defining FLUENT_SNIPPETS_STORAGE_DIR constant in wp-config.php
+     * 2. Using the 'fluent_snippets/storage_dir' filter
+     *
+     * Example for wp-config.php:
+     * define('FLUENT_SNIPPETS_STORAGE_DIR', ABSPATH . 'wp-content/uploads/fluent-snippets');
+     *
+     * Example filter usage:
+     * add_filter('fluent_snippets/storage_dir', function($path) {
+     *     return WP_CONTENT_DIR . '/uploads/fluent-snippets';
+     * });
+     *
+     * @return string The storage directory path
+     */
     public static function getStorageDir()
     {
-        return WP_CONTENT_DIR . '/fluent-snippet-storage';
+        // Check for constant first (can be defined in wp-config.php)
+        if (defined('FLUENT_SNIPPETS_STORAGE_DIR') && FLUENT_SNIPPETS_STORAGE_DIR) {
+            $path = untrailingslashit(FLUENT_SNIPPETS_STORAGE_DIR);
+            return apply_filters('fluent_snippets/storage_dir', $path);
+        }
+
+        $defaultPath = WP_CONTENT_DIR . '/fluent-snippet-storage';
+
+        return apply_filters('fluent_snippets/storage_dir', $defaultPath);
+    }
+
+    /**
+     * Get the URL for the storage directory.
+     *
+     * Users can customize this URL by:
+     * 1. Defining FLUENT_SNIPPETS_STORAGE_URL constant in wp-config.php
+     * 2. Using the 'fluent_snippets/storage_url' filter
+     *
+     * @return string The storage directory URL
+     */
+    public static function getStorageUrl()
+    {
+        // Check for constant first
+        if (defined('FLUENT_SNIPPETS_STORAGE_URL') && FLUENT_SNIPPETS_STORAGE_URL) {
+            $url = untrailingslashit(FLUENT_SNIPPETS_STORAGE_URL);
+            return apply_filters('fluent_snippets/storage_url', $url);
+        }
+
+        // Try to calculate URL from path
+        $storageDir = self::getStorageDir();
+        $defaultDir = WP_CONTENT_DIR . '/fluent-snippet-storage';
+
+        // If using default path, use default URL
+        if ($storageDir === $defaultDir) {
+            $url = content_url('/fluent-snippet-storage');
+        } else {
+            // Try to determine URL from path
+            // Check if path is within uploads directory
+            $uploadsDir = wp_upload_dir();
+            $uploadsBasedir = untrailingslashit($uploadsDir['basedir']);
+            $uploadsBaseurl = untrailingslashit($uploadsDir['baseurl']);
+
+            if (strpos($storageDir, $uploadsBasedir) === 0) {
+                // Path is within uploads, calculate relative URL
+                $relativePath = substr($storageDir, strlen($uploadsBasedir));
+                $url = $uploadsBaseurl . $relativePath;
+            } elseif (strpos($storageDir, WP_CONTENT_DIR) === 0) {
+                // Path is within wp-content, calculate relative URL
+                $relativePath = substr($storageDir, strlen(WP_CONTENT_DIR));
+                $url = content_url($relativePath);
+            } else {
+                // Fallback: try to calculate from ABSPATH
+                if (strpos($storageDir, ABSPATH) === 0) {
+                    $relativePath = substr($storageDir, strlen(ABSPATH));
+                    $url = site_url('/' . $relativePath);
+                } else {
+                    // Cannot determine URL, use default
+                    $url = content_url('/fluent-snippet-storage');
+                }
+            }
+        }
+
+        return apply_filters('fluent_snippets/storage_url', $url);
     }
 
     public static function getCachedDir()

--- a/app/Services/CodeRunner.php
+++ b/app/Services/CodeRunner.php
@@ -6,10 +6,12 @@ class CodeRunner
 {
 
     private $storageDir = '';
+    private $storageUrl = '';
 
     public function __construct()
     {
-        $this->storageDir = WP_CONTENT_DIR . '/fluent-snippet-storage';
+        $this->storageDir = \FluentSnippets\App\Helpers\Helper::getStorageDir();
+        $this->storageUrl = \FluentSnippets\App\Helpers\Helper::getStorageUrl();
     }
 
     public function runSnippets()
@@ -325,6 +327,6 @@ class CodeRunner
             return false;
         }
 
-        return content_url('/fluent-snippet-storage/cached/' . $fileName);
+        return $this->storageUrl . '/cached/' . $fileName;
     }
 }

--- a/app/Services/mu.stub
+++ b/app/Services/mu.stub
@@ -359,10 +359,77 @@ class CodeRunner
 {
 
     private $storageDir = '';
+    private $storageUrl = '';
 
     public function __construct()
     {
-        $this->storageDir = WP_CONTENT_DIR . '/fluent-snippet-storage';
+        $this->storageDir = $this->resolveStorageDir();
+        $this->storageUrl = $this->resolveStorageUrl();
+    }
+
+    /**
+     * Resolve the storage directory path.
+     * Supports FLUENT_SNIPPETS_STORAGE_DIR constant and fluent_snippets/storage_dir filter.
+     */
+    private function resolveStorageDir()
+    {
+        // Check for constant first (can be defined in wp-config.php)
+        if (defined('FLUENT_SNIPPETS_STORAGE_DIR') && FLUENT_SNIPPETS_STORAGE_DIR) {
+            $path = untrailingslashit(FLUENT_SNIPPETS_STORAGE_DIR);
+            return apply_filters('fluent_snippets/storage_dir', $path);
+        }
+
+        $defaultPath = WP_CONTENT_DIR . '/fluent-snippet-storage';
+
+        return apply_filters('fluent_snippets/storage_dir', $defaultPath);
+    }
+
+    /**
+     * Resolve the storage URL.
+     * Supports FLUENT_SNIPPETS_STORAGE_URL constant and fluent_snippets/storage_url filter.
+     */
+    private function resolveStorageUrl()
+    {
+        // Check for constant first
+        if (defined('FLUENT_SNIPPETS_STORAGE_URL') && FLUENT_SNIPPETS_STORAGE_URL) {
+            $url = untrailingslashit(FLUENT_SNIPPETS_STORAGE_URL);
+            return apply_filters('fluent_snippets/storage_url', $url);
+        }
+
+        $storageDir = $this->storageDir;
+        $defaultDir = WP_CONTENT_DIR . '/fluent-snippet-storage';
+
+        // If using default path, use default URL
+        if ($storageDir === $defaultDir) {
+            $url = content_url('/fluent-snippet-storage');
+        } else {
+            // Try to determine URL from path
+            // Check if path is within uploads directory
+            $uploadsDir = wp_upload_dir();
+            $uploadsBasedir = untrailingslashit($uploadsDir['basedir']);
+            $uploadsBaseurl = untrailingslashit($uploadsDir['baseurl']);
+
+            if (strpos($storageDir, $uploadsBasedir) === 0) {
+                // Path is within uploads, calculate relative URL
+                $relativePath = substr($storageDir, strlen($uploadsBasedir));
+                $url = $uploadsBaseurl . $relativePath;
+            } elseif (strpos($storageDir, WP_CONTENT_DIR) === 0) {
+                // Path is within wp-content, calculate relative URL
+                $relativePath = substr($storageDir, strlen(WP_CONTENT_DIR));
+                $url = content_url($relativePath);
+            } else {
+                // Fallback: try to calculate from ABSPATH
+                if (strpos($storageDir, ABSPATH) === 0) {
+                    $relativePath = substr($storageDir, strlen(ABSPATH));
+                    $url = site_url('/' . $relativePath);
+                } else {
+                    // Cannot determine URL, use default
+                    $url = content_url('/fluent-snippet-storage');
+                }
+            }
+        }
+
+        return apply_filters('fluent_snippets/storage_url', $url);
     }
 
     public function runSnippets()
@@ -679,7 +746,7 @@ class CodeRunner
             return false;
         }
 
-        return content_url('/fluent-snippet-storage/cached/' . $fileName);
+        return $this->storageUrl . '/cached/' . $fileName;
     }
 }
 


### PR DESCRIPTION
Allow users to customize where snippets are stored by:
- Defining FLUENT_SNIPPETS_STORAGE_DIR constant in wp-config.php
- Using the 'fluent_snippets/storage_dir' filter

This is useful for hosts that lock down the file system and only allow writes to specific directories like wp-content/uploads. Gridpane does this for Git immutable repos and Pantheon does this as well. A user could use symlinks but those are too brittle can be overwritten easily.

Also adds:
- FLUENT_SNIPPETS_STORAGE_URL constant for custom URL
- 'fluent_snippets/storage_url' filter for URL customization
- Automatic URL detection for paths within uploads or wp-content