### PR TITLE
code-rtl-formatter-fix

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -610,6 +610,9 @@ ul.fls_listed_data {
   font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu;
   font-size: 16px;
   line-height: 1.6;
+  direction: ltr !important;
+  text-align: left !important;
+  unicode-bidi: embed;
 }
 
 .ͼ1 .cm-scroller {


### PR DESCRIPTION
code-rtl-formatter-fix

Before: 
<img width="1436" alt="image" src="https://github.com/user-attachments/assets/92b0860a-7008-4d0d-8362-5d31a9c32f07" />


After
<img width="1435" alt="image" src="https://github.com/user-attachments/assets/3ecb34f7-e048-4572-b303-6baa6865dc0a" />