### PR TITLE
Invalidate OPcache after writing snippet engine files

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -26,6 +26,36 @@ class Helper
         return $dir;
     }
 
+    /**
+     * Invalidate the OPcache entry for a snippet/engine file we just wrote.
+     *
+     * Our runtime include()s these PHP files. On hosts where OPcache caches
+     * compiled bytecode (common in Docker/Alpine images, especially with
+     * opcache.validate_timestamps=0), edits stay invisible until PHP-FPM is
+     * restarted. Force-invalidating the exact path makes changes apply on the
+     * next request without a restart.
+     *
+     * This is intentionally a best-effort, no-throw no-op: it does nothing when
+     * OPcache is unavailable, disabled, or restricted via opcache.restrict_api,
+     * so it is safe to call on every write across every hosting environment.
+     *
+     * @param string $file Absolute path to the file that was just written/removed.
+     * @return void
+     */
+    public static function invalidateOpcache($file)
+    {
+        if (!$file || !function_exists('opcache_invalidate')) {
+            return;
+        }
+
+        // force = true so it also invalidates when opcache.validate_timestamps=0.
+        // Silenced because opcache.restrict_api can emit a warning for callers
+        // outside the allowed path prefix; in that case it is simply a no-op.
+        @opcache_invalidate($file, true);
+
+        clearstatcache(true, $file);
+    }
+
     public static function validateCode($language, $code)
     {
         if (!$code) {
@@ -184,7 +214,11 @@ PHP;
 
         $code .= 'return ' . var_export($data, true) . ';';
 
-        return file_put_contents($cacheFile, $code);
+        $bytesWritten = file_put_contents($cacheFile, $code);
+
+        self::invalidateOpcache($cacheFile);
+
+        return $bytesWritten;
     }
 
     public static function getIndexedConfig($cached = true)

--- a/app/Model/Snippet.php
+++ b/app/Model/Snippet.php
@@ -278,6 +278,8 @@ class Snippet
 
         file_put_contents($file, $fullCode);
 
+        Helper::invalidateOpcache($file);
+
         $type = Arr::get($metaData, 'type');
 
         if ($type == 'css' || $type == 'js') {
@@ -323,6 +325,8 @@ class Snippet
 
         file_put_contents($file, $fullCode);
 
+        Helper::invalidateOpcache($file);
+
         $this->maybeCacheCssJs($fileName, $metaData, $code);
 
         return $fileName;
@@ -338,6 +342,8 @@ class Snippet
         }
 
         unlink($file);
+
+        Helper::invalidateOpcache($file);
 
         return true;
     }


### PR DESCRIPTION
Snippets and the master index.php config are loaded at runtime via include/require_once. On hosts running OPcache with opcache.validate_timestamps=0 (common in Docker/Alpine PHP-FPM images), the compiled bytecode is never re-checked against disk, so edits, renames, group changes, and deletes stay frozen until PHP-FPM is restarted (e.g. a container restart).

Add Helper::invalidateOpcache() and call it after every write/unlink of an included engine file (index.php config, create, update, delete). It is a fully guarded, no-throw no-op where OPcache is absent, disabled, or restricted via opcache.restrict_api, so it is safe across all hosts. Existing file_put_contents/unlink calls and their return values are left unchanged. URL-served CSS/JS cache files are intentionally not touched (they are not include()d).

Note: opcache_invalidate only clears the SHM of the container/process that handles the request, so split admin/front-end PHP-FPM containers still need opcache.validate_timestamps=1.