### PR TITLE
Add custom snippets storage path (constant-based)

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -10,85 +10,87 @@ class Helper
     /**
      * Get the storage directory path for snippets.
      *
-     * Users can customize this path by:
-     * 1. Defining FLUENT_SNIPPETS_STORAGE_DIR constant in wp-config.php
-     * 2. Using the 'fluent_snippets/storage_dir' filter
+     * The location can be overridden with the FLUENT_SNIPPETS_STORAGE_DIR constant in
+     * wp-config.php. A constant is used (rather than a filter) on purpose: the standalone
+     * mu-plugin runner loads before themes and regular plugins, so only a value available
+     * at config-load time stays consistent between where snippets are written and where
+     * they are read and executed.
      *
      * Example for wp-config.php:
-     * define('FLUENT_SNIPPETS_STORAGE_DIR', ABSPATH . 'wp-content/uploads/fluent-snippets');
+     * define('FLUENT_SNIPPETS_STORAGE_DIR', WP_CONTENT_DIR . '/uploads/fluent-snippets');
      *
-     * Example filter usage:
-     * add_filter('fluent_snippets/storage_dir', function($path) {
-     *     return WP_CONTENT_DIR . '/uploads/fluent-snippets';
-     * });
+     * NOTE: keep this logic in sync with CodeRunner::resolveStorageDir() in app/Services/mu.stub
      *
-     * @return string The storage directory path
+     * @return string The storage directory path (no trailing slash)
      */
     public static function getStorageDir()
     {
-        // Check for constant first (can be defined in wp-config.php)
         if (defined('FLUENT_SNIPPETS_STORAGE_DIR') && FLUENT_SNIPPETS_STORAGE_DIR) {
-            $path = untrailingslashit(FLUENT_SNIPPETS_STORAGE_DIR);
-            return apply_filters('fluent_snippets/storage_dir', $path);
+            return untrailingslashit(FLUENT_SNIPPETS_STORAGE_DIR);
         }
 
-        $defaultPath = WP_CONTENT_DIR . '/fluent-snippet-storage';
-
-        return apply_filters('fluent_snippets/storage_dir', $defaultPath);
+        return WP_CONTENT_DIR . '/fluent-snippet-storage';
     }
 
     /**
      * Get the URL for the storage directory.
      *
-     * Users can customize this URL by:
-     * 1. Defining FLUENT_SNIPPETS_STORAGE_URL constant in wp-config.php
-     * 2. Using the 'fluent_snippets/storage_url' filter
+     * The URL can be overridden with the FLUENT_SNIPPETS_STORAGE_URL constant in
+     * wp-config.php. When not set, it is derived from the storage directory path.
      *
-     * @return string The storage directory URL
+     * NOTE: keep this logic in sync with CodeRunner::resolveStorageUrl() in app/Services/mu.stub
+     *
+     * @return string The storage directory URL (no trailing slash)
      */
     public static function getStorageUrl()
     {
-        // Check for constant first
         if (defined('FLUENT_SNIPPETS_STORAGE_URL') && FLUENT_SNIPPETS_STORAGE_URL) {
-            $url = untrailingslashit(FLUENT_SNIPPETS_STORAGE_URL);
-            return apply_filters('fluent_snippets/storage_url', $url);
+            return untrailingslashit(FLUENT_SNIPPETS_STORAGE_URL);
         }
 
-        // Try to calculate URL from path
-        $storageDir = self::getStorageDir();
+        return self::deriveStorageUrl(self::getStorageDir());
+    }
+
+    /**
+     * Derive a public URL for a storage directory that lives inside a known WordPress root.
+     *
+     * NOTE: keep this logic in sync with CodeRunner::deriveStorageUrl() in app/Services/mu.stub
+     *
+     * @param string $storageDir Absolute path, no trailing slash.
+     * @return string
+     */
+    protected static function deriveStorageUrl($storageDir)
+    {
         $defaultDir = WP_CONTENT_DIR . '/fluent-snippet-storage';
-
-        // If using default path, use default URL
         if ($storageDir === $defaultDir) {
-            $url = content_url('/fluent-snippet-storage');
-        } else {
-            // Try to determine URL from path
-            // Check if path is within uploads directory
-            $uploadsDir = wp_upload_dir();
-            $uploadsBasedir = untrailingslashit($uploadsDir['basedir']);
-            $uploadsBaseurl = untrailingslashit($uploadsDir['baseurl']);
-
-            if (strpos($storageDir, $uploadsBasedir) === 0) {
-                // Path is within uploads, calculate relative URL
-                $relativePath = substr($storageDir, strlen($uploadsBasedir));
-                $url = $uploadsBaseurl . $relativePath;
-            } elseif (strpos($storageDir, WP_CONTENT_DIR) === 0) {
-                // Path is within wp-content, calculate relative URL
-                $relativePath = substr($storageDir, strlen(WP_CONTENT_DIR));
-                $url = content_url($relativePath);
-            } else {
-                // Fallback: try to calculate from ABSPATH
-                if (strpos($storageDir, ABSPATH) === 0) {
-                    $relativePath = substr($storageDir, strlen(ABSPATH));
-                    $url = site_url('/' . $relativePath);
-                } else {
-                    // Cannot determine URL, use default
-                    $url = content_url('/fluent-snippet-storage');
-                }
-            }
+            return content_url('/fluent-snippet-storage');
         }
 
-        return apply_filters('fluent_snippets/storage_url', $url);
+        // Path inside uploads/ (the recommended target for locked-down hosts).
+        $uploadsDir = wp_upload_dir();
+        $uploadsBasedir = untrailingslashit($uploadsDir['basedir']);
+        if (strpos($storageDir, $uploadsBasedir) === 0) {
+            return untrailingslashit($uploadsDir['baseurl']) . substr($storageDir, strlen($uploadsBasedir));
+        }
+
+        // Path inside wp-content/.
+        if (strpos($storageDir, WP_CONTENT_DIR) === 0) {
+            return content_url(substr($storageDir, strlen(WP_CONTENT_DIR)));
+        }
+
+        // Path inside the WordPress root.
+        if (strpos($storageDir, untrailingslashit(ABSPATH)) === 0) {
+            return site_url(substr($storageDir, strlen(untrailingslashit(ABSPATH))));
+        }
+
+        // Path is outside every known root: the URL cannot be derived. Fail loud so the
+        // misconfiguration is visible instead of silently serving broken cached-asset URLs.
+        // The site keeps working; only cached CSS/JS asset URLs are affected.
+        if (defined('WP_DEBUG') && WP_DEBUG) {
+            error_log('FluentSnippets: cannot derive a URL for storage dir "' . $storageDir . '". Define FLUENT_SNIPPETS_STORAGE_URL in wp-config.php.');
+        }
+
+        return content_url('/fluent-snippet-storage');
     }
 
     public static function getCachedDir()

--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -7,9 +7,88 @@ use FluentSnippets\App\Services\PhpValidator;
 
 class Helper
 {
+    /**
+     * Get the storage directory path for snippets.
+     *
+     * Users can customize this path by:
+     * 1. Defining FLUENT_SNIPPETS_STORAGE_DIR constant in wp-config.php
+     * 2. Using the 'fluent_snippets/storage_dir' filter
+     *
+     * Example for wp-config.php:
+     * define('FLUENT_SNIPPETS_STORAGE_DIR', ABSPATH . 'wp-content/uploads/fluent-snippets');
+     *
+     * Example filter usage:
+     * add_filter('fluent_snippets/storage_dir', function($path) {
+     *     return WP_CONTENT_DIR . '/uploads/fluent-snippets';
+     * });
+     *
+     * @return string The storage directory path
+     */
     public static function getStorageDir()
     {
-        return WP_CONTENT_DIR . '/fluent-snippet-storage';
+        // Check for constant first (can be defined in wp-config.php)
+        if (defined('FLUENT_SNIPPETS_STORAGE_DIR') && FLUENT_SNIPPETS_STORAGE_DIR) {
+            $path = untrailingslashit(FLUENT_SNIPPETS_STORAGE_DIR);
+            return apply_filters('fluent_snippets/storage_dir', $path);
+        }
+
+        $defaultPath = WP_CONTENT_DIR . '/fluent-snippet-storage';
+
+        return apply_filters('fluent_snippets/storage_dir', $defaultPath);
+    }
+
+    /**
+     * Get the URL for the storage directory.
+     *
+     * Users can customize this URL by:
+     * 1. Defining FLUENT_SNIPPETS_STORAGE_URL constant in wp-config.php
+     * 2. Using the 'fluent_snippets/storage_url' filter
+     *
+     * @return string The storage directory URL
+     */
+    public static function getStorageUrl()
+    {
+        // Check for constant first
+        if (defined('FLUENT_SNIPPETS_STORAGE_URL') && FLUENT_SNIPPETS_STORAGE_URL) {
+            $url = untrailingslashit(FLUENT_SNIPPETS_STORAGE_URL);
+            return apply_filters('fluent_snippets/storage_url', $url);
+        }
+
+        // Try to calculate URL from path
+        $storageDir = self::getStorageDir();
+        $defaultDir = WP_CONTENT_DIR . '/fluent-snippet-storage';
+
+        // If using default path, use default URL
+        if ($storageDir === $defaultDir) {
+            $url = content_url('/fluent-snippet-storage');
+        } else {
+            // Try to determine URL from path
+            // Check if path is within uploads directory
+            $uploadsDir = wp_upload_dir();
+            $uploadsBasedir = untrailingslashit($uploadsDir['basedir']);
+            $uploadsBaseurl = untrailingslashit($uploadsDir['baseurl']);
+
+            if (strpos($storageDir, $uploadsBasedir) === 0) {
+                // Path is within uploads, calculate relative URL
+                $relativePath = substr($storageDir, strlen($uploadsBasedir));
+                $url = $uploadsBaseurl . $relativePath;
+            } elseif (strpos($storageDir, WP_CONTENT_DIR) === 0) {
+                // Path is within wp-content, calculate relative URL
+                $relativePath = substr($storageDir, strlen(WP_CONTENT_DIR));
+                $url = content_url($relativePath);
+            } else {
+                // Fallback: try to calculate from ABSPATH
+                if (strpos($storageDir, ABSPATH) === 0) {
+                    $relativePath = substr($storageDir, strlen(ABSPATH));
+                    $url = site_url('/' . $relativePath);
+                } else {
+                    // Cannot determine URL, use default
+                    $url = content_url('/fluent-snippet-storage');
+                }
+            }
+        }
+
+        return apply_filters('fluent_snippets/storage_url', $url);
     }
 
     public static function getCachedDir()

--- a/app/Services/CodeRunner.php
+++ b/app/Services/CodeRunner.php
@@ -6,10 +6,12 @@ class CodeRunner
 {
 
     private $storageDir = '';
+    private $storageUrl = '';
 
     public function __construct()
     {
-        $this->storageDir = WP_CONTENT_DIR . '/fluent-snippet-storage';
+        $this->storageDir = \FluentSnippets\App\Helpers\Helper::getStorageDir();
+        $this->storageUrl = \FluentSnippets\App\Helpers\Helper::getStorageUrl();
     }
 
     public function runSnippets()
@@ -325,6 +327,6 @@ class CodeRunner
             return false;
         }
 
-        return content_url('/fluent-snippet-storage/cached/' . $fileName);
+        return $this->storageUrl . '/cached/' . $fileName;
     }
 }

--- a/app/Services/mu.stub
+++ b/app/Services/mu.stub
@@ -369,67 +369,75 @@ class CodeRunner
 
     /**
      * Resolve the storage directory path.
-     * Supports FLUENT_SNIPPETS_STORAGE_DIR constant and fluent_snippets/storage_dir filter.
+     *
+     * Overridable with the FLUENT_SNIPPETS_STORAGE_DIR constant in wp-config.php. This
+     * runner loads before themes and regular plugins, so a constant (available at
+     * config-load time) is the only override that stays consistent with the main plugin.
+     *
+     * NOTE: keep this logic in sync with Helper::getStorageDir().
      */
     private function resolveStorageDir()
     {
-        // Check for constant first (can be defined in wp-config.php)
         if (defined('FLUENT_SNIPPETS_STORAGE_DIR') && FLUENT_SNIPPETS_STORAGE_DIR) {
-            $path = untrailingslashit(FLUENT_SNIPPETS_STORAGE_DIR);
-            return apply_filters('fluent_snippets/storage_dir', $path);
+            return untrailingslashit(FLUENT_SNIPPETS_STORAGE_DIR);
         }
 
-        $defaultPath = WP_CONTENT_DIR . '/fluent-snippet-storage';
-
-        return apply_filters('fluent_snippets/storage_dir', $defaultPath);
+        return WP_CONTENT_DIR . '/fluent-snippet-storage';
     }
 
     /**
      * Resolve the storage URL.
-     * Supports FLUENT_SNIPPETS_STORAGE_URL constant and fluent_snippets/storage_url filter.
+     *
+     * Overridable with the FLUENT_SNIPPETS_STORAGE_URL constant in wp-config.php. When
+     * not set, it is derived from the storage directory path.
+     *
+     * NOTE: keep this logic in sync with Helper::getStorageUrl().
      */
     private function resolveStorageUrl()
     {
-        // Check for constant first
         if (defined('FLUENT_SNIPPETS_STORAGE_URL') && FLUENT_SNIPPETS_STORAGE_URL) {
-            $url = untrailingslashit(FLUENT_SNIPPETS_STORAGE_URL);
-            return apply_filters('fluent_snippets/storage_url', $url);
+            return untrailingslashit(FLUENT_SNIPPETS_STORAGE_URL);
         }
 
-        $storageDir = $this->storageDir;
+        return $this->deriveStorageUrl($this->storageDir);
+    }
+
+    /**
+     * Derive a public URL for a storage directory that lives inside a known WordPress root.
+     *
+     * NOTE: keep this logic in sync with Helper::deriveStorageUrl().
+     */
+    private function deriveStorageUrl($storageDir)
+    {
         $defaultDir = WP_CONTENT_DIR . '/fluent-snippet-storage';
-
-        // If using default path, use default URL
         if ($storageDir === $defaultDir) {
-            $url = content_url('/fluent-snippet-storage');
-        } else {
-            // Try to determine URL from path
-            // Check if path is within uploads directory
-            $uploadsDir = wp_upload_dir();
-            $uploadsBasedir = untrailingslashit($uploadsDir['basedir']);
-            $uploadsBaseurl = untrailingslashit($uploadsDir['baseurl']);
-
-            if (strpos($storageDir, $uploadsBasedir) === 0) {
-                // Path is within uploads, calculate relative URL
-                $relativePath = substr($storageDir, strlen($uploadsBasedir));
-                $url = $uploadsBaseurl . $relativePath;
-            } elseif (strpos($storageDir, WP_CONTENT_DIR) === 0) {
-                // Path is within wp-content, calculate relative URL
-                $relativePath = substr($storageDir, strlen(WP_CONTENT_DIR));
-                $url = content_url($relativePath);
-            } else {
-                // Fallback: try to calculate from ABSPATH
-                if (strpos($storageDir, ABSPATH) === 0) {
-                    $relativePath = substr($storageDir, strlen(ABSPATH));
-                    $url = site_url('/' . $relativePath);
-                } else {
-                    // Cannot determine URL, use default
-                    $url = content_url('/fluent-snippet-storage');
-                }
-            }
+            return content_url('/fluent-snippet-storage');
         }
 
-        return apply_filters('fluent_snippets/storage_url', $url);
+        // Path inside uploads/ (the recommended target for locked-down hosts).
+        $uploadsDir = wp_upload_dir();
+        $uploadsBasedir = untrailingslashit($uploadsDir['basedir']);
+        if (strpos($storageDir, $uploadsBasedir) === 0) {
+            return untrailingslashit($uploadsDir['baseurl']) . substr($storageDir, strlen($uploadsBasedir));
+        }
+
+        // Path inside wp-content/.
+        if (strpos($storageDir, WP_CONTENT_DIR) === 0) {
+            return content_url(substr($storageDir, strlen(WP_CONTENT_DIR)));
+        }
+
+        // Path inside the WordPress root.
+        if (strpos($storageDir, untrailingslashit(ABSPATH)) === 0) {
+            return site_url(substr($storageDir, strlen(untrailingslashit(ABSPATH))));
+        }
+
+        // Path is outside every known root: the URL cannot be derived. Fail loud so the
+        // misconfiguration is visible instead of silently serving broken cached-asset URLs.
+        if (defined('WP_DEBUG') && WP_DEBUG) {
+            error_log('FluentSnippets: cannot derive a URL for storage dir "' . $storageDir . '". Define FLUENT_SNIPPETS_STORAGE_URL in wp-config.php.');
+        }
+
+        return content_url('/fluent-snippet-storage');
     }
 
     public function runSnippets()

--- a/app/Services/mu.stub
+++ b/app/Services/mu.stub
@@ -359,10 +359,77 @@ class CodeRunner
 {
 
     private $storageDir = '';
+    private $storageUrl = '';
 
     public function __construct()
     {
-        $this->storageDir = WP_CONTENT_DIR . '/fluent-snippet-storage';
+        $this->storageDir = $this->resolveStorageDir();
+        $this->storageUrl = $this->resolveStorageUrl();
+    }
+
+    /**
+     * Resolve the storage directory path.
+     * Supports FLUENT_SNIPPETS_STORAGE_DIR constant and fluent_snippets/storage_dir filter.
+     */
+    private function resolveStorageDir()
+    {
+        // Check for constant first (can be defined in wp-config.php)
+        if (defined('FLUENT_SNIPPETS_STORAGE_DIR') && FLUENT_SNIPPETS_STORAGE_DIR) {
+            $path = untrailingslashit(FLUENT_SNIPPETS_STORAGE_DIR);
+            return apply_filters('fluent_snippets/storage_dir', $path);
+        }
+
+        $defaultPath = WP_CONTENT_DIR . '/fluent-snippet-storage';
+
+        return apply_filters('fluent_snippets/storage_dir', $defaultPath);
+    }
+
+    /**
+     * Resolve the storage URL.
+     * Supports FLUENT_SNIPPETS_STORAGE_URL constant and fluent_snippets/storage_url filter.
+     */
+    private function resolveStorageUrl()
+    {
+        // Check for constant first
+        if (defined('FLUENT_SNIPPETS_STORAGE_URL') && FLUENT_SNIPPETS_STORAGE_URL) {
+            $url = untrailingslashit(FLUENT_SNIPPETS_STORAGE_URL);
+            return apply_filters('fluent_snippets/storage_url', $url);
+        }
+
+        $storageDir = $this->storageDir;
+        $defaultDir = WP_CONTENT_DIR . '/fluent-snippet-storage';
+
+        // If using default path, use default URL
+        if ($storageDir === $defaultDir) {
+            $url = content_url('/fluent-snippet-storage');
+        } else {
+            // Try to determine URL from path
+            // Check if path is within uploads directory
+            $uploadsDir = wp_upload_dir();
+            $uploadsBasedir = untrailingslashit($uploadsDir['basedir']);
+            $uploadsBaseurl = untrailingslashit($uploadsDir['baseurl']);
+
+            if (strpos($storageDir, $uploadsBasedir) === 0) {
+                // Path is within uploads, calculate relative URL
+                $relativePath = substr($storageDir, strlen($uploadsBasedir));
+                $url = $uploadsBaseurl . $relativePath;
+            } elseif (strpos($storageDir, WP_CONTENT_DIR) === 0) {
+                // Path is within wp-content, calculate relative URL
+                $relativePath = substr($storageDir, strlen(WP_CONTENT_DIR));
+                $url = content_url($relativePath);
+            } else {
+                // Fallback: try to calculate from ABSPATH
+                if (strpos($storageDir, ABSPATH) === 0) {
+                    $relativePath = substr($storageDir, strlen(ABSPATH));
+                    $url = site_url('/' . $relativePath);
+                } else {
+                    // Cannot determine URL, use default
+                    $url = content_url('/fluent-snippet-storage');
+                }
+            }
+        }
+
+        return apply_filters('fluent_snippets/storage_url', $url);
     }
 
     public function runSnippets()
@@ -679,7 +746,7 @@ class CodeRunner
             return false;
         }
 
-        return content_url('/fluent-snippet-storage/cached/' . $fileName);
+        return $this->storageUrl . '/cached/' . $fileName;
     }
 }
 


### PR DESCRIPTION
Allow relocating snippet storage for hosts that lock down the filesystem (Gridpane, Pantheon, etc.) by defining constants in `wp-config.php`:

- `FLUENT_SNIPPETS_STORAGE_DIR` — where snippet files are written/read
- `FLUENT_SNIPPETS_STORAGE_URL` — public URL for cached assets (auto-derived when omitted)

```php
// wp-config.php
define('FLUENT_SNIPPETS_STORAGE_DIR', WP_CONTENT_DIR . '/uploads/fluent-snippets');
```

### Credit
Builds on @digisavvy's work in #43 (DigiSavvy-Inc). The original commit is preserved in this branch; this PR rebases it onto current `master` and adds a refinement pass.

### What changed vs #43
- **Constant-only (filters removed).** The original exposed `fluent_snippets/storage_dir` / `_url` filters. The standalone mu-plugin runner loads *before* themes and regular plugins, so a filter registered there never applied to the runner — the admin would write snippets to the filtered path while the runner read (and failed to find them at) the default path, silently stopping snippets. Constants are defined in `wp-config.php` and are visible to both the main plugin and the mu-plugin, so write-path and execute-path stay in sync.
- **Shared URL derivation** (`deriveStorageUrl()`) in both `Helper` and the `mu.stub` runner, with "keep in sync" notes on each copy.
- **Fail loud** (`error_log` under `WP_DEBUG`) when a custom dir sits outside every known WordPress root and no URL constant is set, instead of silently returning a wrong default URL.
- **Rebased onto master** so it no longer conflicts with / reverts the recent OPcache invalidation work.

### Testing
- `php -l` clean on `Helper.php`, `CodeRunner.php`, `mu.stub`.
- Default path (no constants) → unchanged behavior.
- Custom dir under `uploads/` → URL derived from the uploads base URL.

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)